### PR TITLE
Code lint

### DIFF
--- a/packages/isar/lib/src/isar_connect.dart
+++ b/packages/isar/lib/src/isar_connect.dart
@@ -72,7 +72,8 @@ abstract class _IsarConnect {
       if (path.endsWith('=')) {
         path = path.substring(0, path.length - 1);
       }
-      final url = ' https://isar-community.dev/inspector/${Isar.version}/#/$port$path ';
+      final url =
+          ' https://isar-community.dev/inspector/${Isar.version}/#/$port$path ';
       String line(String text, String fill) {
         final fillCount = url.length - text.length;
         final left = List.filled(fillCount ~/ 2, fill);

--- a/packages/isar/lib/src/native/bindings.dart
+++ b/packages/isar/lib/src/native/bindings.dart
@@ -2024,8 +2024,8 @@ class IsarCoreBindings {
   }
 
   late final _isar_q_aggregate_long_resultPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Int64 Function(ffi.Pointer<CAggregationResult>)>>(
+          ffi
+          .NativeFunction<ffi.Int64 Function(ffi.Pointer<CAggregationResult>)>>(
       'isar_q_aggregate_long_result');
   late final _isar_q_aggregate_long_result = _isar_q_aggregate_long_resultPtr
       .asFunction<int Function(ffi.Pointer<CAggregationResult>)>();
@@ -2088,9 +2088,9 @@ class IsarCoreBindings {
   }
 
   late final _isar_txn_finishPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-              ffi.Pointer<CIsarTxn>, ffi.Bool)>>('isar_txn_finish');
+          ffi
+          .NativeFunction<ffi.Int64 Function(ffi.Pointer<CIsarTxn>, ffi.Bool)>>(
+      'isar_txn_finish');
   late final _isar_txn_finish = _isar_txn_finishPtr
       .asFunction<int Function(ffi.Pointer<CIsarTxn>, bool)>();
 

--- a/packages/isar_generator/lib/src/code_gen/query_filter_length.dart
+++ b/packages/isar_generator/lib/src/code_gen/query_filter_length.dart
@@ -8,8 +8,7 @@ String generateLength(
     String includeLower,
     String upper,
     String includeUpper,
-  )
-      codeGen,
+  ) codeGen,
 ) {
   return '''
       QueryBuilder<$objectName, $objectName, QAfterFilterCondition> ${propertyName.decapitalize()}LengthEqualTo(int length) {


### PR DESCRIPTION
Changes after running `dart format . --set-exit-if-changed`. 

Required for passing lint: https://github.com/isar-community/isar/pull/18