### PR TITLE
Fix binaries url

### DIFF
--- a/packages/isar/lib/src/web/web.dart
+++ b/packages/isar/lib/src/web/web.dart
@@ -14,7 +14,7 @@ export 'interop.dart';
 FutureOr<IsarCoreBindings> initializePlatformBindings([
   String? library,
 ]) async {
-  final url = library ?? 'https://unpkg.com/isar@${Isar.version}/isar.wasm';
+  final url = library ?? 'https://binaries.isar-community.dev/${Isar.version}/isar.wasm';
   final w = window as JSWindow;
   final promise = w.WebAssembly.instantiateStreaming(
     w.fetch(url),

--- a/packages/isar/lib/src/web/web.dart
+++ b/packages/isar/lib/src/web/web.dart
@@ -14,7 +14,8 @@ export 'interop.dart';
 FutureOr<IsarCoreBindings> initializePlatformBindings([
   String? library,
 ]) async {
-  final url = library ?? 'https://binaries.isar-community.dev/${Isar.version}/isar.wasm';
+  final url = library ??
+      'https://binaries.isar-community.dev/${Isar.version}/isar.wasm';
   final w = window as JSWindow;
   final promise = w.WebAssembly.instantiateStreaming(
     w.fetch(url),

--- a/tool/download_binaries.sh
+++ b/tool/download_binaries.sh
@@ -5,19 +5,19 @@ if [ -z "$ISAR_VERSION" ]; then
     exit 2;
 fi
 
-github="https://github.com/isar-community/isar/releases/download/$ISAR_VERSION"
+binariesUrl="https://binaries.isar-community.dev/$ISAR_VERSION"
 
 
-curl "${github}/libisar_android_arm64.so" -o packages/isar_flutter_libs/android/src/main/jniLibs/arm64-v8a/libisar.so --create-dirs -L -f
-curl "${github}/libisar_android_armv7.so" -o packages/isar_flutter_libs/android/src/main/jniLibs/armeabi-v7a/libisar.so --create-dirs -L -f
-curl "${github}/libisar_android_x64.so" -o packages/isar_flutter_libs/android/src/main/jniLibs/x86_64/libisar.so --create-dirs -L
+curl "${binariesUrl}/libisar_android_arm64.so" -o packages/isar_flutter_libs/android/src/main/jniLibs/arm64-v8a/libisar.so --create-dirs -L -f
+curl "${binariesUrl}/libisar_android_armv7.so" -o packages/isar_flutter_libs/android/src/main/jniLibs/armeabi-v7a/libisar.so --create-dirs -L -f
+curl "${binariesUrl}/libisar_android_x64.so" -o packages/isar_flutter_libs/android/src/main/jniLibs/x86_64/libisar.so --create-dirs -L
 
-curl "${github}/isar_ios.xcframework.zip" -o packages/isar_flutter_libs/ios/isar_ios.xcframework.zip --create-dirs -L -f
+curl "${binariesUrl}/isar_ios.xcframework.zip" -o packages/isar_flutter_libs/ios/isar_ios.xcframework.zip --create-dirs -L -f
 unzip -o packages/isar_flutter_libs/ios/isar_ios.xcframework.zip -d packages/isar_flutter_libs/ios
 rm packages/isar_flutter_libs/ios/isar_ios.xcframework.zip
 
-curl "${github}/libisar_macos.dylib" -o packages/isar_flutter_libs/macos/libisar.dylib --create-dirs -L -f
-curl "${github}/libisar_linux_x64.so" -o packages/isar_flutter_libs/linux/libisar.so --create-dirs -L -f
-curl "${github}/isar_windows_x64.dll" -o packages/isar_flutter_libs/windows/isar.dll --create-dirs -L -f
+curl "${binariesUrl}/libisar_macos.dylib" -o packages/isar_flutter_libs/macos/libisar.dylib --create-dirs -L -f
+curl "${binariesUrl}/libisar_linux_x64.so" -o packages/isar_flutter_libs/linux/libisar.so --create-dirs -L -f
+curl "${binariesUrl}/isar_windows_x64.dll" -o packages/isar_flutter_libs/windows/isar.dll --create-dirs -L -f
 
-curl "${github}/isar.wasm" -o isar.wasm -L -f
+curl "${binariesUrl}/isar.wasm" -o isar.wasm -L -f


### PR DESCRIPTION
Binaries are now being downloaded from github pages, that supports direct downloads and `application/wasm` headers. For now, I have manually uploaded files from version `4.0.1`, but the repository is greenlit for automated releases

Fixes https://github.com/isar-community/isar/issues/28

Fixes PR #36 

Related? https://github.com/isar-community/isar/issues/30