### PR TITLE
sets to loose js version

### DIFF
--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   ffi: ">=2.0.0 <3.0.0"
 #  isar_test:
 #    path: ../isar_test
-  js: ^0.6.4
+  js: any
   meta: ^1.7.0
 
 dev_dependencies:


### PR DESCRIPTION
We can safely set to `any` as web bindings are not available to v3

Fixes #16