### PR TITLE
Use correct hosted URL in Quickstart in Readme

### DIFF
--- a/packages/isar/README.md
+++ b/packages/isar/README.md
@@ -70,15 +70,15 @@ isar_version: &isar_version 3.1.3 # define the version to be used
 dependencies:
   isar: 
     version: *isar_version
-    hosted: https://pub.isar-community.dev/
+    hosted: https://isar-community.dev/
   isar_flutter_libs: # contains Isar Core
     version: *isar_version
-    hosted: https://pub.isar-community.dev/
+    hosted: https://isar-community.dev/
 
 dev_dependencies:
   isar_generator: 
     version: *isar_version
-    hosted: https://pub.isar-community.dev/
+    hosted: https://isar-community.dev/
   build_runner: any
 
 ```


### PR DESCRIPTION
It seems that the pub URL in the readme is not correct.

For me `https://pub.isar-community.dev/` did not work, but `https://isar-community.dev/` did.

Not sure if the project is about to switch URLs though. The error message was:

```
Because isar_generator >=3.1.3 <3.1.4 depends on isar from hosted on https://isar-community.dev and shared depends on isar from hosted on https://pub.isar-community.dev, isar_generator >=3.1.3 <3.1.4 is forbidden.
So, because shared depends on isar_generator 3.1.3, version solving failed.
```