### PR TITLE
fix web compatibility

### DIFF
--- a/packages/isar/lib/isar.dart
+++ b/packages/isar/lib/isar.dart
@@ -17,6 +17,9 @@ import 'package:isar/src/native/split_words.dart'
 import 'package:meta/meta.dart';
 import 'package:meta/meta_meta.dart';
 
+export 'dart:convert';
+export 'package:xxh3/xxh3.dart';
+
 part 'src/annotations/backlink.dart';
 part 'src/annotations/collection.dart';
 part 'src/annotations/embedded.dart';

--- a/packages/isar/lib/src/native/bindings.dart
+++ b/packages/isar/lib/src/native/bindings.dart
@@ -2024,8 +2024,8 @@ class IsarCoreBindings {
   }
 
   late final _isar_q_aggregate_long_resultPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Int64 Function(ffi.Pointer<CAggregationResult>)>>(
+          ffi
+          .NativeFunction<ffi.Int64 Function(ffi.Pointer<CAggregationResult>)>>(
       'isar_q_aggregate_long_result');
   late final _isar_q_aggregate_long_result = _isar_q_aggregate_long_resultPtr
       .asFunction<int Function(ffi.Pointer<CAggregationResult>)>();
@@ -2088,9 +2088,9 @@ class IsarCoreBindings {
   }
 
   late final _isar_txn_finishPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Int64 Function(
-              ffi.Pointer<CIsarTxn>, ffi.Bool)>>('isar_txn_finish');
+          ffi
+          .NativeFunction<ffi.Int64 Function(ffi.Pointer<CIsarTxn>, ffi.Bool)>>(
+      'isar_txn_finish');
   late final _isar_txn_finish = _isar_txn_finishPtr
       .asFunction<int Function(ffi.Pointer<CIsarTxn>, bool)>();
 

--- a/packages/isar/lib/src/schema/collection_schema.dart
+++ b/packages/isar/lib/src/schema/collection_schema.dart
@@ -5,7 +5,7 @@ class CollectionSchema<OBJ> extends Schema<OBJ> {
   /// @nodoc
   @protected
   const CollectionSchema({
-    required super.id,
+    required super.idGenerator,
     required super.name,
     required super.properties,
     required super.estimateSize,
@@ -31,7 +31,7 @@ class CollectionSchema<OBJ> extends Schema<OBJ> {
   factory CollectionSchema.fromJson(Map<String, dynamic> json) {
     final collection = Schema<dynamic>.fromJson(json);
     return CollectionSchema(
-      id: collection.id,
+      idGenerator: collection.idGenerator,
       name: collection.name,
       properties: collection.properties,
       idName: json['idName'] as String,

--- a/packages/isar/lib/src/schema/index_schema.dart
+++ b/packages/isar/lib/src/schema/index_schema.dart
@@ -5,7 +5,7 @@ class IndexSchema {
   /// @nodoc
   @protected
   const IndexSchema({
-    required this.id,
+    required this.idGenerator,
     required this.name,
     required this.unique,
     required this.replace,
@@ -16,7 +16,7 @@ class IndexSchema {
   @protected
   factory IndexSchema.fromJson(Map<String, dynamic> json) {
     return IndexSchema(
-      id: -1,
+      idGenerator: () => -1,
       name: json['name'] as String,
       unique: json['unique'] as bool,
       replace: json['replace'] as bool,
@@ -27,7 +27,9 @@ class IndexSchema {
   }
 
   /// Internal id of this index.
-  final int id;
+  int get id => idGenerator();
+
+  final int Function() idGenerator;
 
   /// Name of this index.
   final String name;

--- a/packages/isar/lib/src/schema/link_schema.dart
+++ b/packages/isar/lib/src/schema/link_schema.dart
@@ -5,7 +5,7 @@ class LinkSchema {
   /// @nodoc
   @protected
   const LinkSchema({
-    required this.id,
+    required this.idGenerator,
     required this.name,
     required this.target,
     required this.single,
@@ -16,7 +16,7 @@ class LinkSchema {
   @protected
   factory LinkSchema.fromJson(Map<String, dynamic> json) {
     return LinkSchema(
-      id: -1,
+      idGenerator: () => -1,
       name: json['name'] as String,
       target: json['target'] as String,
       single: json['single'] as bool,
@@ -25,7 +25,9 @@ class LinkSchema {
   }
 
   /// Internal id of this link.
-  final int id;
+  int get id => idGenerator();
+
+  final int Function() idGenerator;
 
   /// Name of this link.
   final String name;

--- a/packages/isar/lib/src/schema/schema.dart
+++ b/packages/isar/lib/src/schema/schema.dart
@@ -5,7 +5,7 @@ class Schema<OBJ> {
   /// @nodoc
   @protected
   const Schema({
-    required this.id,
+    required this.idGenerator,
     required this.name,
     required this.properties,
     required this.estimateSize,
@@ -18,7 +18,7 @@ class Schema<OBJ> {
   @protected
   factory Schema.fromJson(Map<String, dynamic> json) {
     return Schema(
-      id: -1,
+      idGenerator: () => -1,
       name: json['name'] as String,
       properties: {
         for (final property in json['properties'] as List<dynamic>)
@@ -33,7 +33,9 @@ class Schema<OBJ> {
   }
 
   /// Internal id of this collection or embedded object.
-  final int id;
+  int get id => idGenerator();
+
+  final int Function() idGenerator;
 
   /// Name of the collection or embedded object
   final String name;

--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 #    path: ../isar_test
   js: any
   meta: ^1.7.0
+  xxh3: ^1.0.1
 
 dev_dependencies:
   ffigen: "^7.0.0"

--- a/packages/isar_generator/lib/src/code_gen/collection_schema_generator.dart
+++ b/packages/isar_generator/lib/src/code_gen/collection_schema_generator.dart
@@ -20,7 +20,7 @@ String generateSchema(ObjectInfo object) {
 
   code += '''
     name: r'${object.isarName}',
-    id: ${object.id},
+    idGenerator: ${object.generateIdName},
     properties: {$properties},
 
     estimateSize: ${object.estimateSizeName},
@@ -88,7 +88,7 @@ String _generateIndexSchema(ObjectIndex index) {
 
   return '''
     IndexSchema(
-      id: ${index.id},
+      idGenerator: ${index.id},
       name: r'${index.name}',
       unique: ${index.unique},
       replace: ${index.replace},

--- a/packages/isar_generator/lib/src/code_gen/type_adapter_generator.dart
+++ b/packages/isar_generator/lib/src/code_gen/type_adapter_generator.dart
@@ -406,6 +406,14 @@ String _deserialize(ObjectProperty property, String propertyOffset) {
   }
 }
 
+String generateGenerateId(ObjectInfo object) {
+  return '''
+    int ${object.generateIdName}() {
+      return xxh3(utf8.encode(r'${object.isarName}'));
+    }
+  ''';
+}
+
 String generateGetId(ObjectInfo object) {
   final defaultVal = object.idProperty.nullable ? '?? Isar.autoIncrement' : '';
   return '''

--- a/packages/isar_generator/lib/src/collection_generator.dart
+++ b/packages/isar_generator/lib/src/collection_generator.dart
@@ -61,6 +61,7 @@ class IsarCollectionGenerator extends GeneratorForAnnotation<Collection> {
 
       ${generateEnumMaps(object)}
 
+      ${generateGenerateId(object)}
       ${generateGetId(object)}
       ${generateGetLinks(object)}
       ${generateAttach(object)}
@@ -91,6 +92,7 @@ class IsarEmbeddedGenerator extends GeneratorForAnnotation<Embedded> {
 
       ${generateSchema(object)}
 
+      ${generateGenerateId(object)}
       ${generateEstimateSerialize(object)}
       ${generateSerialize(object)}
       ${generateDeserialize(object)}

--- a/packages/isar_generator/lib/src/object_info.dart
+++ b/packages/isar_generator/lib/src/object_info.dart
@@ -4,8 +4,6 @@ import 'dart:typed_data';
 import 'package:dartx/dartx.dart';
 import 'package:isar/isar.dart';
 
-import 'package:xxh3/xxh3.dart';
-
 class ObjectInfo {
   ObjectInfo({
     required this.dartName,
@@ -27,8 +25,6 @@ class ObjectInfo {
   final List<ObjectIndex> indexes;
   final List<ObjectLink> links;
 
-  int get id => xxh3(utf8.encode(isarName) as Uint8List);
-
   bool get isEmbedded => accessor == null;
 
   ObjectProperty get idProperty => properties.firstWhere((it) => it.isId);
@@ -36,6 +32,7 @@ class ObjectInfo {
   List<ObjectProperty> get objectProperties =>
       properties.where((it) => !it.isId).toList();
 
+  String get generateIdName => '_${dartName.decapitalize()}GenerateId';
   String get getIdName => '_${dartName.decapitalize()}GetId';
   String get getLinksName => '_${dartName.decapitalize()}GetLinks';
   String get attachName => '_${dartName.decapitalize()}Attach';
@@ -177,7 +174,7 @@ class ObjectIndex {
   final bool unique;
   final bool replace;
 
-  late final id = xxh3(utf8.encode(name) as Uint8List);
+  int id() => xxh3(utf8.encode(name));
 }
 
 class ObjectLink {
@@ -203,9 +200,9 @@ class ObjectLink {
 
   int id(String objectIsarName) {
     final col = isBacklink ? targetCollectionIsarName : objectIsarName;
-    final colId = xxh3(utf8.encode(col) as Uint8List, seed: isBacklink ? 1 : 0);
+    final colId = xxh3(utf8.encode(col), seed: isBacklink ? 1 : 0);
 
     final name = targetLinkIsarName ?? isarName;
-    return xxh3(utf8.encode(name) as Uint8List, seed: colId);
+    return xxh3(utf8.encode(name), seed: colId);
   }
 }

--- a/packages/isar_generator/pubspec.yaml
+++ b/packages/isar_generator/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
     hosted: https://pub.isar-community.dev
   path: ^1.8.1
   source_gen: ^1.2.2
-  xxh3: ^1.0.1
 
 dev_dependencies:
   build_test: ^2.1.5


### PR DESCRIPTION
Instead of storing the ids of the isar collections as integers, I moved to generation of those integers (which are just hashes of the name property) to runtime. this way, the dart code does not contain integers that cannot be represented in javascript.