### PR TITLE
Update compileSdkVersion to fix Android release build

### DIFF
--- a/packages/isar/CHANGELOG.md
+++ b/packages/isar/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.8
+
+### Fixes
+
+Fix Android release build on Flutter 3.24.0
+
 ## 3.1.7
 
 ### Fixes

--- a/packages/isar/README.md
+++ b/packages/isar/README.md
@@ -65,7 +65,7 @@ Holy smokes you're here! Let's get started on using the coolest Flutter database
 ### 1. Add to pubspec.yaml
 
 ```yaml
-isar_version: &isar_version 3.1.7 # define the version to be used
+isar_version: &isar_version 3.1.8 # define the version to be used
 
 dependencies:
   isar: 

--- a/packages/isar/lib/src/isar.dart
+++ b/packages/isar/lib/src/isar.dart
@@ -18,7 +18,7 @@ abstract class Isar {
   }
 
   /// The version of the Isar library.
-  static const version = '3.1.7';
+  static const version = '3.1.8';
 
   /// Smallest valid id.
   static const Id minId = isarMinId;

--- a/packages/isar/pubspec.yaml
+++ b/packages/isar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isar
 description: Extremely fast, easy to use, and fully async NoSQL database for Flutter.
-version: 3.1.7
+version: 3.1.8
 repository: https://github.com/isar-community/isar/tree/main/packages/isar
 homepage: https://github.com/isar-community/isar
 issue_tracker: https://github.com/isar-community/isar/issues

--- a/packages/isar_flutter_libs/android/build.gradle
+++ b/packages/isar_flutter_libs/android/build.gradle
@@ -26,7 +26,7 @@ android {
         namespace 'dev.isar.isar_flutter_libs'
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/isar_flutter_libs/pubspec.yaml
+++ b/packages/isar_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isar_flutter_libs
 description: Isar Core binaries for the Isar Database. Needs to be included for Flutter apps.
-version: 3.1.7
+version: 3.1.8
 repository: https://github.com/isar-community/isar
 homepage: https://isar.dev
 publish_to: https://pub.isar-community.dev/
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   isar: 
-    version: 3.1.7
+    version: 3.1.8
     hosted: https://pub.isar-community.dev
 
 flutter:

--- a/packages/isar_generator/pubspec.yaml
+++ b/packages/isar_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isar_generator
 description: Code generator for the Isar Database. Finds classes annotated with @Collection.
-version: 3.1.7
+version: 3.1.8
 repository: https://github.com/isar-community/isar
 homepage: https://isar.dev
 publish_to: https://pub.isar-community.dev/
@@ -15,7 +15,7 @@ dependencies:
   dartx: ^1.1.0
   glob: ^2.0.2
   isar: 
-    version: 3.1.7
+    version: 3.1.8
     hosted: https://pub.isar-community.dev
   path: ^1.8.1
   source_gen: ^1.2.2


### PR DESCRIPTION
Should fix #96, 34 is the version used currently by default in flutter.