### PR TITLE
Updated analyzer breaking changes and source_gen dependancies

### DIFF
--- a/packages/isar_generator/lib/src/code_gen/collection_schema_generator.dart
+++ b/packages/isar_generator/lib/src/code_gen/collection_schema_generator.dart
@@ -1,6 +1,5 @@
 import 'package:dartx/dartx.dart';
 import 'package:isar/isar.dart';
-import 'package:isar_generator/src/isar_type.dart';
 
 import 'package:isar_generator/src/object_info.dart';
 

--- a/packages/isar_generator/lib/src/helper.dart
+++ b/packages/isar_generator/lib/src/helper.dart
@@ -26,12 +26,12 @@ extension ClassElementX on ClassElement {
     final ignoreFields =
         collectionAnnotation?.ignore ?? embeddedAnnotation!.ignore;
     return [
-      ...accessors.mapNotNull((e) => e.variable),
+      ...accessors.mapNotNull((e) => e.variable2),
       if (collectionAnnotation?.inheritance ?? embeddedAnnotation!.inheritance)
-        for (InterfaceType supertype in allSupertypes) ...[
+        for (final InterfaceType supertype in allSupertypes) ...[
           if (!supertype.isDartCoreObject)
-            ...supertype.accessors.mapNotNull((e) => e.variable)
-        ]
+            ...supertype.accessors.mapNotNull((e) => e.variable2),
+        ],
     ]
         .where(
           (PropertyInducingElement e) =>
@@ -50,9 +50,9 @@ extension ClassElementX on ClassElement {
 }
 
 extension PropertyElementX on PropertyInducingElement {
-  bool get isLink => type.element2!.name == 'IsarLink';
+  bool get isLink => type.element!.name == 'IsarLink';
 
-  bool get isLinks => type.element2!.name == 'IsarLinks';
+  bool get isLinks => type.element!.name == 'IsarLinks';
 
   Enumerated? get enumeratedAnnotation {
     final ann = _enumeratedChecker.firstAnnotationOfExact(nonSynthetic);

--- a/packages/isar_generator/lib/src/isar_analyzer.dart
+++ b/packages/isar_generator/lib/src/isar_analyzer.dart
@@ -146,7 +146,7 @@ class IsarAnalyzer {
         properties.length) {
       err(
         'Two or more properties have the same name.',
-        constructor.enclosingElement,
+        constructor.enclosingElement3,
       );
     }
 
@@ -162,21 +162,21 @@ class IsarAnalyzer {
   }
 
   Map<String, String> _getEmbeddedDartNames(ClassElement element) {
-    void _fillNames(Map<String, String> names, ClassElement element) {
+    void fillNames(Map<String, String> names, ClassElement element) {
       for (final property in element.allAccessors) {
         final type = property.type.scalarType.element;
         if (type is ClassElement && type.embeddedAnnotation != null) {
           final isarName = type.isarName;
           if (!names.containsKey(isarName)) {
             names[type.isarName] = type.displayName;
-            _fillNames(names, type);
+            fillNames(names, type);
           }
         }
       }
     }
 
     final names = <String, String>{};
-    _fillNames(names, element);
+    fillNames(names, element);
     return names;
   }
 

--- a/packages/isar_generator/lib/src/isar_type.dart
+++ b/packages/isar_generator/lib/src/isar_type.dart
@@ -27,9 +27,9 @@ extension DartTypeX on DartType {
       }
     } else if (isDartCoreString) {
       return IsarType.string;
-    } else if (_isDateTime(element2!)) {
+    } else if (_isDateTime(element!)) {
       return IsarType.dateTime;
-    } else if (element2!.embeddedAnnotation != null) {
+    } else if (element!.embeddedAnnotation != null) {
       return IsarType.object;
     }
 

--- a/packages/isar_generator/lib/src/object_info.dart
+++ b/packages/isar_generator/lib/src/object_info.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:dartx/dartx.dart';
 import 'package:isar/isar.dart';
@@ -27,7 +26,7 @@ class ObjectInfo {
   final List<ObjectIndex> indexes;
   final List<ObjectLink> links;
 
-  int get id => xxh3(utf8.encode(isarName) as Uint8List);
+  int get id => xxh3(utf8.encode(isarName));
 
   bool get isEmbedded => accessor == null;
 
@@ -177,7 +176,7 @@ class ObjectIndex {
   final bool unique;
   final bool replace;
 
-  late final id = xxh3(utf8.encode(name) as Uint8List);
+  late final id = xxh3(utf8.encode(name));
 }
 
 class ObjectLink {
@@ -203,9 +202,9 @@ class ObjectLink {
 
   int id(String objectIsarName) {
     final col = isBacklink ? targetCollectionIsarName : objectIsarName;
-    final colId = xxh3(utf8.encode(col) as Uint8List, seed: isBacklink ? 1 : 0);
+    final colId = xxh3(utf8.encode(col), seed: isBacklink ? 1 : 0);
 
     final name = targetLinkIsarName ?? isarName;
-    return xxh3(utf8.encode(name) as Uint8List, seed: colId);
+    return xxh3(utf8.encode(name), seed: colId);
   }
 }

--- a/packages/isar_generator/pubspec.yaml
+++ b/packages/isar_generator/pubspec.yaml
@@ -6,23 +6,23 @@ homepage: https://isar.dev
 publish_to: https://pub.isar-community.dev/
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=4.6.0 <7.0.0"
+  analyzer: ">=4.6.0 <=7.3.0"
   build: ^2.3.0
-  dart_style: ^2.2.3
+  dart_style: ^3.0.1
   dartx: ^1.1.0
   glob: ^2.0.2
-  isar: 
+  isar:
     version: 3.1.8
     hosted: https://pub.isar-community.dev
   path: ^1.8.1
-  source_gen: ^1.2.2
+  source_gen: ^2.0.0
   xxh3: ^1.0.1
 
 dev_dependencies:
   build_test: ^2.1.5
   matcher: ^0.12.12
   test: ^1.21.0
-  very_good_analysis: ^3.0.1
+  very_good_analysis: ^7.0.0


### PR DESCRIPTION
All tests pass, I believe anaylzer depricated these values a while ago and 7.3.0 was the final removal. I don't have any build_runner errors or dependancy issues in my current project.

I've potentially been to liberal here, as I've fixed some dart lint errors as well. Happy to pair back a bit as required